### PR TITLE
Remove git ref

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,8 +12,7 @@
     <engine name="cordova" version=">=3.4.0"/>
   </engines>
 
-  <dependency id="com.phonegap.plugins.barcodescanner" url="https://github.com/wildabeast/BarcodeScanner.git"
-              commit="HEAD" />
+  <dependency id="com.phonegap.plugins.barcodescanner"/>
 
   <js-module src="www/aerogear-opt.js" name="AeroGear.Totp">
     <clobbers target="cordova.plugins.totp"/>


### PR DESCRIPTION
The barcode scanner plugin is now available in Cordova's registry (http://plugins.cordova.io/#/package/com.phonegap.plugins.barcodescanner), so the git reference is not needed anymore. Also, this make it easier under the Windows platform, where git is not on available on the command line (at least not under the same command line where Cordova CLI runs ;) ).
@edewit can you review ? 
